### PR TITLE
Switch all SQL queries to parameterized statements

### DIFF
--- a/eversolar.pl
+++ b/eversolar.pl
@@ -1073,10 +1073,9 @@ while (42) {
                       . $inverters{$inverter}{"serial"} );
 
                 my $stmt =
-                  "select min(e_total) as mins from daily where timestamp  >=   date('now', '-365 day') and serial_number = '"
-                  . $inverters{$inverter}{"serial"} . "'";
+                  "select min(e_total) as mins from daily where timestamp  >=   date('now', '-365 day') and serial_number = ?";
                 my $sth = $dbh->prepare($stmt);
-                my $rv  = $sth->execute() or die $DBI::errstr;
+                my $rv  = $sth->execute($inverters{$inverter}{"serial"}) or die $DBI::errstr;
                 if ( $rv < 0 ) {
                      print $DBI::errstr;
                 }

--- a/eversolar.pl
+++ b/eversolar.pl
@@ -1069,7 +1069,7 @@ while (42) {
             $combined_daykwh = $combined_daykwh + $data[ $DATA_BYTES{'E_TODAY'} ] / 100;
 
             if ( $inverters{$inverter}{"daily_retrieved"} == 0 ) {
-                pmu_log( "Severity 3, select min(e_total) as mins from daily where timestamp  >=   date('now', '-1 year') and serial_number = "
+                pmu_log( "Severity 3, select min(e_total) as mins from daily where timestamp >= date('now', '-365 day') and serial_number = "
                       . $inverters{$inverter}{"serial"} );
 
                 my $stmt =
@@ -1153,7 +1153,7 @@ while (42) {
                     $inverters{$inverter}{"data"}{"hours_up"},
                     $inverters{$inverter}{"data"}{"op_mode"},
                     $inverters{$inverter}{"data"}{"temp"}
-                ) or die $DBI::errstr;
+                ) or pmu_log("Severity 1, failed to insert inverter data for " . $inverters{$inverter}{"serial"} . ": " . $DBI::errstr);
             }
 
             if ( $data[ $DATA_BYTES{'PAC'} ] > $inverters{$inverter}{"max"}{"pac"}{"watts"} ) {
@@ -1655,17 +1655,19 @@ while (42) {
                          pmax_time)
                     VALUES (?, ?, ?, ?, ?, ?)
                 ");
-                $sth_daily->execute(
+                if ( $sth_daily->execute(
                     $inverters{$inverter}{"serial"},
                     $inverters{$inverter}{"data"}{"timestamp"},
                     $inverters{$inverter}{"data"}{"e_today"},
                     $inverters{$inverter}{"data"}{"e_total"},
                     $inverters{$inverter}{"max"}{"pac"}{"watts"},
                     $inverters{$inverter}{"max"}{"pac"}{"timestamp"}
-                ) or die $DBI::errstr;
-                
-                $inverters{$inverter}{"daily_stored"} = 1;
-                pmu_log("Severity 3, daily stored because end of day");
+                ) ) {
+                    $inverters{$inverter}{"daily_stored"} = 1;
+                    pmu_log("Severity 3, daily stored because end of day");
+                } else {
+                    pmu_log("Severity 1, failed to store daily entry: " . $sth_daily->errstr);
+                }
             }
             
             if ( $hour == 1 && $min == 1 ) {
@@ -1702,17 +1704,18 @@ while (42) {
                          pmax_time)
                     VALUES (?, ?, ?, ?, ?, ?)
                 ");
-                $sth_daily_timeout->execute(
+                if ( $sth_daily_timeout->execute(
                     $inverters{$inverter}{"serial"},
                     $inverters{$inverter}{"data"}{"timestamp"},
                     $inverters{$inverter}{"data"}{"e_today"},
                     $inverters{$inverter}{"data"}{"e_total"},
                     $inverters{$inverter}{"max"}{"pac"}{"watts"},
                     $inverters{$inverter}{"max"}{"pac"}{"timestamp"}
-                ) or die $DBI::errstr;
-                    
-                pmu_log("Severity 4, daily store insert statement: $stmt");
-                pmu_log("Severity 2, daily stored because inverter removed");
+                ) ) {
+                    pmu_log("Severity 2, daily stored because inverter removed");
+                } else {
+                    pmu_log("Severity 1, failed to store daily entry for removed inverter " . $inverters{$inverter}{"serial"} . ": " . $DBI::errstr);
+                }
 
                 # forget about the inverter
                 delete $inverters{$inverter};

--- a/eversolar.pl
+++ b/eversolar.pl
@@ -1116,7 +1116,7 @@ while (42) {
             if ( $config->database_log ) {
 
                 # store in db
-                my $sth_inv = $dbh->prepare("
+                my $sth_inv = $dbh->prepare_cached("
                 INSERT INTO inverter
                     (serial_number,
                      timestamp,
@@ -1136,24 +1136,29 @@ while (42) {
                      temp)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ");
-                $sth_inv->execute(
-                    $inverters{$inverter}{"serial"},
-                    $inverters{$inverter}{"data"}{"timestamp"},
-                    $inverters{$inverter}{"data"}{"pac"},
-                    $inverters{$inverter}{"data"}{"e_today"},
-                    $inverters{$inverter}{"data"}{"e_total"},
-                    $inverters{$inverter}{"data"}{"vpv"},
-                    $inverters{$inverter}{"data"}{"vpv2"},
-                    $inverters{$inverter}{"data"}{"ipv"},
-                    $inverters{$inverter}{"data"}{"ipv2"},
-                    $inverters{$inverter}{"data"}{"vac"},
-                    $inverters{$inverter}{"data"}{"iac"},
-                    $inverters{$inverter}{"data"}{"frequency"},
-                    $inverters{$inverter}{"data"}{"impedance"},
-                    $inverters{$inverter}{"data"}{"hours_up"},
-                    $inverters{$inverter}{"data"}{"op_mode"},
-                    $inverters{$inverter}{"data"}{"temp"}
-                ) or pmu_log("Severity 1, failed to insert inverter data for " . $inverters{$inverter}{"serial"} . ": " . $DBI::errstr);
+                if ( !defined $sth_inv ) {
+                    pmu_log("Severity 1, failed to prepare inverter data insert for " . $inverters{$inverter}{"serial"} . ": " . $dbh->errstr);
+                }
+                else {
+                    $sth_inv->execute(
+                        $inverters{$inverter}{"serial"},
+                        $inverters{$inverter}{"data"}{"timestamp"},
+                        $inverters{$inverter}{"data"}{"pac"},
+                        $inverters{$inverter}{"data"}{"e_today"},
+                        $inverters{$inverter}{"data"}{"e_total"},
+                        $inverters{$inverter}{"data"}{"vpv"},
+                        $inverters{$inverter}{"data"}{"vpv2"},
+                        $inverters{$inverter}{"data"}{"ipv"},
+                        $inverters{$inverter}{"data"}{"ipv2"},
+                        $inverters{$inverter}{"data"}{"vac"},
+                        $inverters{$inverter}{"data"}{"iac"},
+                        $inverters{$inverter}{"data"}{"frequency"},
+                        $inverters{$inverter}{"data"}{"impedance"},
+                        $inverters{$inverter}{"data"}{"hours_up"},
+                        $inverters{$inverter}{"data"}{"op_mode"},
+                        $inverters{$inverter}{"data"}{"temp"}
+                    ) or pmu_log("Severity 1, failed to insert inverter data for " . $inverters{$inverter}{"serial"} . ": " . $sth_inv->errstr);
+                }
             }
 
             if ( $data[ $DATA_BYTES{'PAC'} ] > $inverters{$inverter}{"max"}{"pac"}{"watts"} ) {
@@ -1655,7 +1660,9 @@ while (42) {
                          pmax_time)
                     VALUES (?, ?, ?, ?, ?, ?)
                 ");
-                if ( $sth_daily->execute(
+                if ( !defined $sth_daily ) {
+                    pmu_log("Severity 1, failed to prepare daily entry: " . $dbh->errstr);
+                } elsif ( $sth_daily->execute(
                     $inverters{$inverter}{"serial"},
                     $inverters{$inverter}{"data"}{"timestamp"},
                     $inverters{$inverter}{"data"}{"e_today"},
@@ -1704,7 +1711,9 @@ while (42) {
                          pmax_time)
                     VALUES (?, ?, ?, ?, ?, ?)
                 ");
-                if ( $sth_daily_timeout->execute(
+                if ( !defined $sth_daily_timeout ) {
+                    pmu_log("Severity 1, failed to prepare daily entry for removed inverter " . $inverters{$inverter}{"serial"} . ": " . $dbh->errstr);
+                } elsif ( $sth_daily_timeout->execute(
                     $inverters{$inverter}{"serial"},
                     $inverters{$inverter}{"data"}{"timestamp"},
                     $inverters{$inverter}{"data"}{"e_today"},
@@ -1714,7 +1723,7 @@ while (42) {
                 ) ) {
                     pmu_log("Severity 2, daily stored because inverter removed");
                 } else {
-                    pmu_log("Severity 1, failed to store daily entry for removed inverter " . $inverters{$inverter}{"serial"} . ": " . $DBI::errstr);
+                    pmu_log("Severity 1, failed to store daily entry for removed inverter " . $inverters{$inverter}{"serial"} . ": " . $sth_daily_timeout->errstr);
                 }
 
                 # forget about the inverter

--- a/eversolar.pl
+++ b/eversolar.pl
@@ -1116,7 +1116,7 @@ while (42) {
             if ( $config->database_log ) {
 
                 # store in db
-                $dbh->do( "
+                my $sth_inv = $dbh->prepare("
                 INSERT INTO inverter
                     (serial_number,
                      timestamp,
@@ -1134,25 +1134,26 @@ while (42) {
                      hours_up,
                      op_mode,
                      temp)
-                VALUES
-                    ('" . $inverters{$inverter}{"serial"} . "',
-                     '" . $inverters{$inverter}{"data"}{"timestamp"} . "',
-                     '" . $inverters{$inverter}{"data"}{"pac"} . "',
-                     '" . $inverters{$inverter}{"data"}{"e_today"} . "',
-                     '" . $inverters{$inverter}{"data"}{"e_total"} . "',
-                     '" . $inverters{$inverter}{"data"}{"vpv"} . "',
-                     '" . $inverters{$inverter}{"data"}{"vpv2"} . "',
-                     '" . $inverters{$inverter}{"data"}{"ipv"} . "',
-                     '" . $inverters{$inverter}{"data"}{"ipv2"} . "',
-                     '" . $inverters{$inverter}{"data"}{"vac"} . "',
-                     '" . $inverters{$inverter}{"data"}{"iac"} . "',
-                     '" . $inverters{$inverter}{"data"}{"frequency"} . "',
-                     '" . $inverters{$inverter}{"data"}{"impedance"} . "',
-                     '" . $inverters{$inverter}{"data"}{"hours_up"} . "',
-                     '" . $inverters{$inverter}{"data"}{"op_mode"} . "',
-                     '" . $inverters{$inverter}{"data"}{"temp"} . "'
-                    )
-            " );
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ");
+                $sth_inv->execute(
+                    $inverters{$inverter}{"serial"},
+                    $inverters{$inverter}{"data"}{"timestamp"},
+                    $inverters{$inverter}{"data"}{"pac"},
+                    $inverters{$inverter}{"data"}{"e_today"},
+                    $inverters{$inverter}{"data"}{"e_total"},
+                    $inverters{$inverter}{"data"}{"vpv"},
+                    $inverters{$inverter}{"data"}{"vpv2"},
+                    $inverters{$inverter}{"data"}{"ipv"},
+                    $inverters{$inverter}{"data"}{"ipv2"},
+                    $inverters{$inverter}{"data"}{"vac"},
+                    $inverters{$inverter}{"data"}{"iac"},
+                    $inverters{$inverter}{"data"}{"frequency"},
+                    $inverters{$inverter}{"data"}{"impedance"},
+                    $inverters{$inverter}{"data"}{"hours_up"},
+                    $inverters{$inverter}{"data"}{"op_mode"},
+                    $inverters{$inverter}{"data"}{"temp"}
+                ) or die $DBI::errstr;
             }
 
             if ( $data[ $DATA_BYTES{'PAC'} ] > $inverters{$inverter}{"max"}{"pac"}{"watts"} ) {
@@ -1644,7 +1645,7 @@ while (42) {
             # Store daily entry end of the day
             if ( $hour == 22 && $min == 58 && $inverters{$inverter}{"daily_stored"} == 0 ) {
                 # store a daily entry
-                $dbh->do( "
+                my $sth_daily = $dbh->prepare("
                     INSERT INTO daily
                         (serial_number,
                          timestamp,
@@ -1652,14 +1653,16 @@ while (42) {
                          e_total,
                          pmax_today,
                          pmax_time)
-                VALUES
-                    ('" . $inverters{$inverter}{"serial"} . "',
-                     '" . $inverters{$inverter}{"data"}{"timestamp"} . "',
-                     '" . $inverters{$inverter}{"data"}{"e_today"} . "',
-                     '" . $inverters{$inverter}{"data"}{"e_total"} . "',
-                     '" . $inverters{$inverter}{"max"}{"pac"}{"watts"} . "',
-                     '" . $inverters{$inverter}{"max"}{"pac"}{"timestamp"} . "'
-                    )" );
+                    VALUES (?, ?, ?, ?, ?, ?)
+                ");
+                $sth_daily->execute(
+                    $inverters{$inverter}{"serial"},
+                    $inverters{$inverter}{"data"}{"timestamp"},
+                    $inverters{$inverter}{"data"}{"e_today"},
+                    $inverters{$inverter}{"data"}{"e_total"},
+                    $inverters{$inverter}{"max"}{"pac"}{"watts"},
+                    $inverters{$inverter}{"max"}{"pac"}{"timestamp"}
+                ) or die $DBI::errstr;
                 
                 $inverters{$inverter}{"daily_stored"} = 1;
                 pmu_log("Severity 3, daily stored because end of day");
@@ -1689,7 +1692,7 @@ while (42) {
                 pmu_log( "Severity 1, " . $inverters{$inverter}{"serial"} . " lost contact with inverter, forgetting inverter" );
 
                 # store a daily entry
-                $stmt = "
+                my $sth_daily_timeout = $dbh->prepare("
                     INSERT INTO daily
                         (serial_number,
                          timestamp,
@@ -1697,16 +1700,16 @@ while (42) {
                          e_total,
                          pmax_today,
                          pmax_time)
-                VALUES
-                    ('" . $inverters{$inverter}{"serial"} . "',
-                     '" . $inverters{$inverter}{"data"}{"timestamp"} . "',
-                     '" . $inverters{$inverter}{"data"}{"e_today"} . "',
-                     '" . $inverters{$inverter}{"data"}{"e_total"} . "',
-                     '" . $inverters{$inverter}{"max"}{"pac"}{"watts"} . "',
-                     '" . $inverters{$inverter}{"max"}{"pac"}{"timestamp"} . "'
-                    )";
-                
-                $dbh->do( $stmt );
+                    VALUES (?, ?, ?, ?, ?, ?)
+                ");
+                $sth_daily_timeout->execute(
+                    $inverters{$inverter}{"serial"},
+                    $inverters{$inverter}{"data"}{"timestamp"},
+                    $inverters{$inverter}{"data"}{"e_today"},
+                    $inverters{$inverter}{"data"}{"e_total"},
+                    $inverters{$inverter}{"max"}{"pac"}{"watts"},
+                    $inverters{$inverter}{"max"}{"pac"}{"timestamp"}
+                ) or die $DBI::errstr;
                     
                 pmu_log("Severity 4, daily store insert statement: $stmt");
                 pmu_log("Severity 2, daily stored because inverter removed");


### PR DESCRIPTION
## What

All SQL queries in `eversolar.pl` that used string concatenation to build statements have been replaced with DBI parameterized queries (`prepare` + `execute` with `?` placeholders).

## Why

The inverter communicates over TCP via an ethernet-to-serial converter. That means the data travelling over the network — serial number, timestamps, energy readings, voltage, current, temperature — could in principle be intercepted and tampered with before it reaches the script. Building SQL statements by concatenating those values directly is unsafe.

Four queries were affected:

- `INSERT INTO inverter` — logs realtime measurements every poll cycle
- `INSERT INTO daily` — stores the end-of-day summary
- `INSERT INTO daily` — stores a summary when an inverter times out and is forgotten
- `SELECT min(e_total) FROM daily` — calculates 365-day production total

## How

Each query now uses `$dbh->prepare(...)` with `?` placeholders, and values are passed as arguments to `->execute(...)`. DBI handles quoting and escaping, so the values are never interpreted as SQL.

On failure, the INSERT statements now log an error via `pmu_log` and continue rather than crashing the script, preserving the original resilient behavior.

## Testing

Tested on a live production system with a TL3000 inverter connected via ethernet-to-serial converter. Realtime data, daily storage and the 365-day production figure all continue to work correctly.