### PR TITLE
Fixed MQTT home assistant issues (Temp and e_today) + Last 365 Days float value

### DIFF
--- a/eversolar.pl
+++ b/eversolar.pl
@@ -1088,7 +1088,7 @@ while (42) {
                 $inverters{$inverter}{"daily_retrieved"} = 1;
             }
             
-            $d365 = $e_total - $inverters{$inverter}{"daily_retrieved_value"};
+            $d365 = sprintf("%.1f", $e_total - $inverters{$inverter}{"daily_retrieved_value"});
             
             pmu_log("Severity 3, " . $inverters{$inverter}{"serial"} . " output: $pac W, Total: $e_total kWh, Today: $e_today_kwh kWh, 365 days : $d365 " );
 

--- a/eversolar.pl
+++ b/eversolar.pl
@@ -1297,7 +1297,7 @@ while (42) {
                    pac => $inverters{$inverter}{'data'}{'pac'},
                    max_power_today => $inverters{$inverter}{'max'}{'pac'}{'watts'},
                    d365 => $inverters{$inverter}{'data'}{'d365'},
-                   total_daykwh => $inverters{$inverter}{'data'}{'total_daykwh'},
+                   total_daykwh => $inverters{$inverter}{'data'}{'e_today'},
                    e_total => $inverters{$inverter}{'data'}{'e_total'},
                    temp => $inverters{$inverter}{'data'}{'temp'},
                    impedance => $inverters{$inverter}{'data'}{'impedance'},
@@ -1354,6 +1354,7 @@ while (42) {
                            $config_data{'name'} = "PV Total Energy Today";
                            $config_data{'unit_of_measurement'} = "kWh";
                            $config_data{'device_class'} = "energy";
+                           $config_data{"state_class"} = "total_increasing";
 
                        } elsif ( $_[0] eq "e_total" ){
                            $config_data{'icon'} = "mdi:solar-power";
@@ -1365,8 +1366,7 @@ while (42) {
                        } elsif ( $_[0] eq "temp" ){
                            $config_data{'icon'} = "mdi:temperature-celsius";
                            $config_data{'name'} = "PV Inverter Temperature";
-                           binmode(STDOUT, ":utf8");
-                           $config_data{'unit_of_measurement'} = "<C2><B0>C";
+                           $config_data{'unit_of_measurement'} = "°C";
                            $config_data{'device_class'} = "temperature";
                            $config_data{'state_class'} = "measurement";
 


### PR DESCRIPTION
d365 was having "infinit" decimals, which messed up web UI and HA sensor readings, a rounding of 1 decimal has been added

the total_daykwh sensor in the MQTT section was transfering the Combined Energy Today as the first inverters total_daykwh, data changed from total_daykwh to e_today

total_daykwh sensor in the MQTT section was missing state_class for HA to use it in the energy dashboard. state_class has been added as "total_increasing"

temp sensor in MQTT section was not discoverable by HA, removed binmode and changed unit to "°C"

Above changes have made implementation in HA Energy dashboard possible, and fixed issues with wrong total_daykwh values for the 1. inverter. Temp sensors are now also auto discoverable by HA.